### PR TITLE
Remove Resources from AppBundle

### DIFF
--- a/src/AppBundle.php
+++ b/src/AppBundle.php
@@ -12,11 +12,5 @@ class AppBundle extends Bundle
     public function build(ContainerBuilder $container)
     {
         parent::build($container);
-
-        $loader = new YamlFileLoader($container, new FileLocator([
-            __DIR__ . '/Resources/config'
-        ]));
-        $loader->load('services.yml');
     }
-
 }

--- a/src/Resources/config/services.yml
+++ b/src/Resources/config/services.yml
@@ -1,6 +1,0 @@
-
-services:
-#    service_name:
-#        class: AppBundle\Directory\ClassName
-#        arguments: ["@another_service_name", "plain_value", "%parameter_name%"]
-


### PR DESCRIPTION
According to the [best practices](http://symfony.com/doc/current/best_practices/configuration.html) it's better to use app/ instead of src/AppBundle/Resources/ to store configs especially services.yml