### PR TITLE
Fix composer install cause of php 7.0.1 requirement

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
         "psr-4": {"features\\App\\": "features/bootstrap"}
     },
     "require": {
-        "php": ">=7.0.1",
+        "php": ">=7.0.0",
         "symfony/symfony": "3.0.*",
         "doctrine/orm": "^2.5",
         "doctrine/doctrine-bundle": "^1.6",

--- a/composer.lock
+++ b/composer.lock
@@ -3331,7 +3331,7 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": ">=7.0.1"
+        "php": ">=7.0.0"
     },
     "platform-dev": []
 }


### PR DESCRIPTION
Docker image **composer/composer:php7** unable to run. The requirement in composer.json is too strict.

```
root8s-MacBook-Pro-102:snsanichsymfonyskeleton isoft$ support/shortcuts/composer install
Loading composer repositories with package information
Installing dependencies (including require-dev) from lock file
Your requirements could not be resolved to an installable set of packages.

  Problem 1
    - This package requires php >=7.0.1 but your PHP version (7.0.0) does not satisfy that requirement.

```

I suggest to loose a bit the restriction for a while.