### PR TITLE
Fix: ability to change symfony-var-dir only if new directory exists, …

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -10,4 +10,5 @@ support/scripts
 support/*.yml
 support/aliases
 support/env
-var
+!var/bootstrap.php.cache
+var/*

--- a/.gitignore
+++ b/.gitignore
@@ -1,10 +1,13 @@
+# IDE
+.idea
+
 # Symfony specific
 /build/
 /vendor/
 /bin/*
 !/bin/healthcheck
 !/bin/console
-/var/
+/var/*
 /composer.phar
 /front/web/bundles
 !.gitkeep


### PR DESCRIPTION
[DistributionBundle](https://github.com/sensiolabs/SensioDistributionBundle/blob/master/Composer/ScriptHandler.php#L464) unable to run command **install:assets**. The bundle has following code
 
```php
protected static function useNewDirectoryStructure(array $options)
    {
        return isset($options['symfony-var-dir']) && is_dir($options['symfony-var-dir']);
    }
```

I suggest to add directory **var** to skeleton.
I also modified **.dockerignore** to keep **var/bootstrap.php.cache** in Docker container (it was forbidden before)