### PR TITLE
Added all environment variables to framework

### DIFF
--- a/app/AppKernel.php
+++ b/app/AppKernel.php
@@ -47,4 +47,24 @@ class AppKernel extends Kernel
     {
         $loader->load($this->getRootDir().'/config/config_'.$this->getEnvironment().'.yml');
     }
+
+    /**
+     * Gets the environment parameters.
+     *
+     * All parameters considered. Parameters will be converted to format "env.variable1.part2"
+     * @example:
+     * POSTGRES_DB - "env.postgres.db"
+     * SYMFONY__DATABASE__NAME - "env.symfony..database..name"
+     *
+     * @return array An array of parameters
+     */
+    protected function getEnvParameters()
+    {
+        $parameters = array();
+        foreach ($_SERVER as $key => $value) {
+            $parameters["env.".strtolower(str_replace('_', '.', $key))] = $value;
+        }
+
+        return $parameters;
+    }
 }

--- a/app/config/parameters.yml
+++ b/app/config/parameters.yml
@@ -4,9 +4,9 @@
 parameters:
     database_host:     database
     database_port:     ~
-    database_name:     %database.name%
-    database_user:     %database.user%
-    database_password: %database.pass%
+    database_name:     %env.postgres.db%
+    database_user:     %env.postgres.user%
+    database_password: %env.postgres.password%
     # You should uncomment this if you want use pdo_sqlite
     # database_path: "%kernel.root_dir%/data.db3"
 
@@ -16,4 +16,4 @@ parameters:
     mailer_password:   ~
 
     # A secret key that's used to generate certain security-related tokens
-    secret:            %app.secret%
+    secret:            %env.app.secret%

--- a/support/env/dev.env
+++ b/support/env/dev.env
@@ -1,4 +1,5 @@
 # PostgreSQL specific
+POSTGRES_DB=example
 POSTGRES_USER=example
 POSTGRES_PASSWORD=example
 PGPASSWORD=example
@@ -6,11 +7,6 @@ PGPASSWORD=example
 # Symfony specific
 SYMFONY_ENV=dev
 
-# Doctrine DBAL Connection params
-SYMFONY__DATABASE__USER=example
-SYMFONY__DATABASE__NAME=example
-SYMFONY__DATABASE__PASS=example
-
 # A secret key that's used to generate certain security-related tokens
 # You can use openssl to generate one
-SYMFONY__APP__SECRET=00e88699d0655da97f008286e8d4c30c28bd5b4a
+APP_SECRET=00e88699d0655da97f008286e8d4c30c28bd5b4a


### PR DESCRIPTION
Code in [Symfony](https://github.com/symfony/symfony/blob/master/src/Symfony/Component/HttpKernel/Kernel.php#L532)

```php
            if (0 === strpos($key, 'SYMFONY__')) {
                $parameters[strtolower(str_replace('__', '.', substr($key, 9)))] = $value;
            }
```
Look like artificial filter. I think it isn't necessary in skeleton with docker anymore.
I suggest to load all $_SERVER variables as parameters, 

My format is follow:

* replace '_' with '.'
* all text should be lowercase.
* add 'env.' text at the start of parameter

Examples:

    POSTGRES_DB - "env.postgres.db"
    SYMFONY__DATABASE__NAME - "env.symfony..database..name"
