### PR TITLE
Build and deploy process based on environment variables

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -6,8 +6,9 @@ README.md
 Makefile
 docker-compose.yml
 front
-support/scripts
-support/*.yml
-support/aliases
-support/env
-var
+
+!support/php
+support/*
+
+!var/bootstrap.php.cache
+var/*

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,7 @@
 /composer.phar
 /front/web/bundles
 !.gitkeep
+
+# deploy tmp files
+/docker-compose.prod.yml
+/prod.env

--- a/support/docker-compose.prod.yml
+++ b/support/docker-compose.prod.yml
@@ -1,0 +1,27 @@
+version: "2"
+services:
+    php:
+        image: "${DOCKER_REPOSITORY}${DOCKER_USER}/${PROJECT_NAME}php:${DOCKER_TAG}"
+        depends_on:
+            - database
+        env_file: prod.env
+        environment:
+            SYMFONY_ENV: prod
+    front:
+        image: "${DOCKER_REPOSITORY}${DOCKER_USER}/${PROJECT_NAME}front:${DOCKER_TAG}"
+        depends_on:
+            - php
+        ports:
+            - 80:80
+
+    database:
+        image: postgres:9.4
+        env_file: prod.env
+        volumes:
+            - dbdata:/var/lib/postgresql
+        ports:
+            - 5432:5432
+
+volumes:
+    dbdata:
+        driver: local

--- a/support/env/dev.env
+++ b/support/env/dev.env
@@ -14,3 +14,10 @@ SYMFONY__DATABASE__PASS=example
 # A secret key that's used to generate certain security-related tokens
 # You can use openssl to generate one
 SYMFONY__APP__SECRET=00e88699d0655da97f008286e8d4c30c28bd5b4a
+
+# Docker registry. Default is "docker.io" value take a look [docker push yourname/newimage](https://docs.docker.com/engine/userguide/containers/dockerrepos/#pushing-a-repository-to-docker-hub)
+DOCKER_REGISTRY=docker.io
+DOCKER_USER=snsanich
+DOCKER_SKIP_LOGIN=
+PROJECT_NAME=myapp
+DOCKER_TAG=latest

--- a/support/scripts/build
+++ b/support/scripts/build
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+
+set -e
+
+dir=$(dirname "${BASH_SOURCE[0]}")
+source "$dir/../env/dev.env"
+export $(cut -f1 "$dir/../env/dev.env" | grep -v "^#.*")
+
+if [ -z "$PROJECT_NAME" ];
+then
+    echo "PROJECT_NAME is not set. Please, define it \"export PROJECT_NAME=myapp\""
+    exit 1
+fi
+
+set +e
+grep -q "auth\"" "$HOME/.docker/config.json"
+exitCode=$?
+set -e
+
+if [ $exitCode -ne 0 ] && [ "$DOCKER_SKIP_LOGIN" != "true" ];
+then
+   echo "You need to run \"docker login\" to your registry\n"
+   exit 1
+fi
+
+# Prepare project
+$dir/../shortcuts/composer install --ignore-platform-reqs
+
+# Generate any documentation here
+
+# Build images
+docker-compose -p $PROJECT_NAME build
+
+echo "Tests done"
+
+# Tag image for dev/test/master branches only
+if [[ "${DOCKER_TAG}" != "" ]]; then
+    echo "Publish docker tag: $DOCKER_TAG"
+
+    docker tag $PROJECT_NAME"_php" "${DOCKER_REGISTRY}${DOCKER_USER}/${PROJECT_NAME}php:$DOCKER_TAG"
+    docker tag $PROJECT_NAME"_front" "${DOCKER_REGISTRY}${DOCKER_USER}/${PROJECT_NAME}front:$DOCKER_TAG"
+
+    docker push "${DOCKER_REGISTRY}${DOCKER_USER}/${PROJECT_NAME}php:$DOCKER_TAG"
+    docker push "${DOCKER_REGISTRY}${DOCKER_USER}/${PROJECT_NAME}front:$DOCKER_TAG"
+else
+    echo "Skip publishing of docker tag - '$DOCKER_TAG'"
+fi

--- a/support/scripts/deploy
+++ b/support/scripts/deploy
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+
+# Please note that this script should be run on server
+set -e
+
+dir=$(dirname "${BASH_SOURCE[0]}")
+source "$dir/../env/dev.env"
+export $(cut -f1 "$dir/../env/dev.env" | grep -v "^#.*")
+
+if [ ! -f prod.env ]; then
+DOCKER_DEPLOY_MACHINE=docker@my-deploy-machine
+>&2 echo "
+
+Broken environment. Please, put file support/env/dev.env as prod.env and update environment variables for your server.
+
+You may use following script on CI or as your deploy script:
+scp support/scripts/deploy $DOCKER_DEPLOY_MACHINE:.
+scp support/docker-compose.prod.yml $DOCKER_DEPLOY_MACHINE:.
+ssh $DOCKER_DEPLOY_MACHINE ./deploy
+";
+
+    exit 1
+fi
+
+
+if [ "$DOCKER_TAG" == "" ]; then
+    echo "Broken environment. Please, verify your prod.env"
+    exit 1
+fi
+
+if [ ! -f docker-compose.prod.yml ]; then
+    echo "Broken docker-compose.yml. Please, put file docker-compose.prod.yml on server in default folder"
+    exit 1
+fi
+
+docker-compose -p $PROJECT_NAME -f docker-compose.prod.yml pull
+docker-compose -p $PROJECT_NAME -f docker-compose.prod.yml up -d


### PR DESCRIPTION
I propose scripts to build and deploy docker images as starter kit.

Both scripts use environment variables:

* DOCKER_REGISTRY - uri path to registry
* DOCKER_USER - name of the user or company
* DOCKER_SKIP_LOGIN - if 'true', we do not verify 'docker login' credentials availability.
* PROJECT_NAME - name of the project.
* DOCKER_TAG - one of the building tags, default 'latest'.


Build script by default:
```bash
sh support/scripts/build
```

Deploy script by default:
```bash
sh support/scripts/deploy
```

I suggest to prepare machine to deploy in following way:
```bash
scp support/env/dev.env $DOCKER_DEPLOY_MACHINE:prod.env
// modify prod.env, change default values
scp support/scripts/deploy $DOCKER_DEPLOY_MACHINE:.
scp support/docker-compose.prod.yml $DOCKER_DEPLOY_MACHINE:.
ssh $DOCKER_DEPLOY_MACHINE ./deploy
```