### PR TITLE
Prepare for docker-compose 1.7: move project name to dotenv

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,1 @@
+COMPOSE_PROJECT_NAME=skeleton

--- a/behat.yml
+++ b/behat.yml
@@ -6,11 +6,9 @@ default:
     suites:
 
         sessions:
-            paths:    [ %paths.base%/features/sessions ]
+            paths:    [ "%paths.base%/features/sessions" ]
             contexts:
-#                - features\PRA\Context\SessionContext:
-#                    userManager: @app_user_manager
-#                    userRepository: @app_user_repository
+              - features\App\Context\SessionContext: []
 
     formatters:
         pretty: true

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -1,0 +1,20 @@
+version: "2"
+
+services:
+    php:
+        env_file: support/env/dev.env
+        volumes:
+            - '.:/srv'
+
+    front:
+        ports:
+            - 0.0.0.0:8080:80
+
+    database:
+        env_file: support/env/dev.env
+        volumes:
+            - dbdata:/var/lib/postgresql
+
+volumes:
+    dbdata:
+        driver: local

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,23 +5,11 @@ services:
         build: '.'
         depends_on:
             - database
-        env_file: support/env/dev.env
-        volumes:
-            - '.:/srv'
 
     front:
         build: 'front'
         depends_on:
             - php
-        ports:
-            - 0.0.0.0:8080:80
 
     database:
         build: 'support/database'
-        env_file: support/env/dev.env
-        volumes:
-            - dbdata:/var/lib/postgresql
-
-volumes:
-    dbdata:
-        driver: local

--- a/features/bootstrap/Context/SessionContext.php
+++ b/features/bootstrap/Context/SessionContext.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace features\App\Context;
+
+use Behat\Behat\Context\SnippetAcceptingContext;
+
+class SessionContext implements SnippetAcceptingContext
+{
+
+}

--- a/features/bootstrap/Support/DoctrineHelperTrait.php
+++ b/features/bootstrap/Support/DoctrineHelperTrait.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace features\PRA\Support;
+namespace features\App\Support;
 
 use Doctrine\ORM\Tools\SchemaTool;
 use Symfony\Component\DependencyInjection\ContainerInterface;

--- a/features/bootstrap/Support/RequestTrait.php
+++ b/features/bootstrap/Support/RequestTrait.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace features\PRA\Support;
+namespace features\App\Support;
 
 use Fesor\JsonMatcher\JsonMatcher;
 use Symfony\Component\HttpFoundation\Request;

--- a/phpspec.yml
+++ b/phpspec.yml
@@ -1,0 +1,5 @@
+suites:
+    main_suite:
+        namespace: App
+        psr4_prefix: App
+    formatter.name: pretty

--- a/support/docker-compose.test.yml
+++ b/support/docker-compose.test.yml
@@ -6,7 +6,3 @@ services:
         read_only: true
         environment:
             SYMFONY_ENV: test
-
-    database:
-        image: postgres:9.4
-        volumes: []

--- a/support/docker-compose.test.yml
+++ b/support/docker-compose.test.yml
@@ -3,6 +3,9 @@ version: "2"
 services:
     php:
         tty: true
-        read_only: true
+        env_file: support/env/dev.env
         environment:
             SYMFONY_ENV: test
+
+    database:
+        env_file: support/env/dev.env

--- a/support/docker-compose.test.yml
+++ b/support/docker-compose.test.yml
@@ -6,6 +6,8 @@ services:
         env_file: support/env/dev.env
         environment:
             SYMFONY_ENV: test
+        volumes:
+            - '.:/srv'
 
     database:
         env_file: support/env/dev.env

--- a/support/scripts/prepare_project
+++ b/support/scripts/prepare_project
@@ -58,6 +58,8 @@ function updateComposerInfo($name, $description, $namespace) {
     unset($composer['autoload-dev']['psr-4']['features\\App\\']);
     $composer['autoload-dev']['psr-4']['features\\' . $namespace . '\\'] = $oldVal;
 
+    unset($composer['scripts']['post-create-project-cmd']);
+
     file_put_contents(
         $composerJson,
         json_encode($composer, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES)
@@ -125,3 +127,5 @@ $projectNamespace = askFor(
 updateComposerInfo($projectName, $projectDescription, $projectNamespace);
 replaceNamespaces($projectNamespace);
 changeDockerComposeProjectName($projectNamespace);
+
+unlink(__FILE__);

--- a/support/scripts/prepare_project
+++ b/support/scripts/prepare_project
@@ -67,8 +67,12 @@ function updateComposerInfo($name, $description, $namespace) {
 function replaceNamespaces($namespaces) {
     $phpPairs = [
         'namespace App' => 'namespace ' . $namespaces,
+        'namespace features\\App' => 'namespace features\\' . $namespaces,
         'use App' => 'use ' . $namespaces,
+        'use features\\App' => 'use features\\' . $namespaces,
         'new App\\' => 'new ' . $namespaces . '\\',
+        '- features\\App' => '- features\\' . $namespaces,
+        ': App' => ': '. $namespaces
     ];
 
     $yamlPairs = [
@@ -77,11 +81,26 @@ function replaceNamespaces($namespaces) {
 
     $files = [
         __DIR__ . '/../../app/AppKernel.php',
-        __DIR__ . '/../../src/AppBundle.php'
+        __DIR__ . '/../../src/AppBundle.php',
+        __DIR__ . '/../../features/bootstrap/Context/SessionContext.php',
+        __DIR__ . '/../../features/bootstrap/Support/DoctrineHelperTrait.php',
+        __DIR__ . '/../../features/bootstrap/Support/RequestTrait.php',
+        __DIR__ . '/../../behat.yml',
+        __DIR__ . '/../../phpspec.yml'
     ];
     foreach ($files as $file) {
         file_put_contents($file, strtr(file_get_contents($file), $phpPairs));
     }
+}
+
+function changeDockerComposeProjectName($projectName)
+{
+    $projectName = strtolower($projectName);
+
+    $file = __DIR__ . '/../../.env';
+    file_put_contents($file, strtr(file_get_contents($file), [
+        'COMPOSE_PROJECT_NAME=skeleton' => 'COMPOSE_PROJECT_NAME=' . $projectName
+    ]));
 }
 
 $projectName = askFor('Project Name [intellectsoft/app]', 'intellectsoft/app', function ($val) {
@@ -105,3 +124,4 @@ $projectNamespace = askFor(
 
 updateComposerInfo($projectName, $projectDescription, $projectNamespace);
 replaceNamespaces($projectNamespace);
+changeDockerComposeProjectName($projectNamespace);

--- a/support/scripts/run_tests
+++ b/support/scripts/run_tests
@@ -1,13 +1,19 @@
 #!/usr/bin/env bash
 
-composeCommand=$(dirname $(dirname "$0"))/shortcuts/compose
-compose="$composeCommand -f docker-compose.yml -f support/docker-compose.test.yml"
+# setup project name
+set -a
+[ -f .env ] && . .env
+set +a
+
+COMPOSE_PROJECT_NAME="{$COMPOSE_PROJECT_NAME}_test"
+
+compose="docker-compose -f docker-compose.yml -f support/docker-compose.test.yml"
 
 # Run phpspec tests
 $compose run --no-deps php bin/phpspec run && \
 
 # Run integration/E2E tests
-$compose up -d database && \
+$compose up --no-deps -d database && \
 $compose run --no-deps php bin/healthcheck 10 && \
 $compose run --no-deps php bin/behat
 

--- a/support/scripts/run_tests
+++ b/support/scripts/run_tests
@@ -1,11 +1,12 @@
 #!/usr/bin/env bash
 
-compose="docker-compose -p app_test -f docker-compose.yml -f support/docker-compose.test.yml"
+composeCommand=$(dirname $(dirname "$0"))/shortcuts/compose
+compose="$composeCommand -f docker-compose.yml -f support/docker-compose.test.yml"
 
 # Run phpspec tests
 $compose run --no-deps php bin/phpspec run && \
 
-# Run integrational/E2E tests
+# Run integration/E2E tests
 $compose up -d database && \
 $compose run --no-deps php bin/healthcheck 10 && \
 $compose run --no-deps php bin/behat

--- a/support/scripts/run_tests
+++ b/support/scripts/run_tests
@@ -14,8 +14,8 @@ $compose run --no-deps php bin/phpspec run && \
 
 # Run integration/E2E tests
 $compose up --no-deps -d database && \
-$compose run --no-deps php bin/healthcheck 10 && \
-$compose run --no-deps php bin/behat
+$compose run --rm --no-deps php bin/healthcheck 10 && \
+$compose run --rm --no-deps php bin/behat
 
 if [ $? -eq 0 ]
 then

--- a/support/shortcuts/behat
+++ b/support/shortcuts/behat
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
 
 compose=$(dirname "$0")/compose
-compose -f docker-compose.yml -f support/docker-compose.test.yml \
+$compose -f docker-compose.yml -f support/docker-compose.test.yml \
          run --no-deps --rm php bin/behat $@

--- a/support/shortcuts/compose
+++ b/support/shortcuts/compose
@@ -1,3 +1,9 @@
 #!/usr/bin/env bash
 
-docker-compose -p app $@
+dotenv () {
+  set -a
+  [ -f .env ] && . .env
+  set +a
+}
+
+dotenv && docker-compose $@

--- a/support/shortcuts/php
+++ b/support/shortcuts/php
@@ -2,4 +2,3 @@
 
 compose=$(dirname "$0")/compose
 $compose run --user $(id -u) --no-deps php $@
-

--- a/support/shortcuts/phpspec
+++ b/support/shortcuts/phpspec
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
 
 compose=$(dirname "$0")/compose
-compose run --user $(id -u) --rm --no-deps php bin/phpspec $@
+$compose run --user $(id -u) --rm --no-deps php bin/phpspec $@


### PR DESCRIPTION
Since docker-compose 1.7 it will be possible to move all project specific stuff to default `.env` file, so developer could specify project name in it.

This PR adds this feature in `compose` shortcut for docker-compose and make use of it in every script. So currently project name specified only in one place.

There is also possibility for future changes, like...

`.env` fiile:
```
APP_DBNAME=example
```

`docker-compose.yml`

```
services:
    php:
        environment:
            SYMFONY__DATABASE__NAME=${APP_DBNAME}
```